### PR TITLE
Matching correct portion type of food_log in nutrition_info

### DIFF
--- a/wwsync/weight_watchers.py
+++ b/wwsync/weight_watchers.py
@@ -129,7 +129,7 @@ def get_nutrition_for_recipe(nutritional_info, food_log):
     ingredient_nutritional_infos = [
         _get_nutrition_for_food(
             ingredient['itemDetail'],
-            ingredient['portionName'],
+            ingredient['portionId'],
             ingredient['quantity']
         ) for ingredient in nutritional_info['ingredients']
     ]

--- a/wwsync/weight_watchers.py
+++ b/wwsync/weight_watchers.py
@@ -162,15 +162,15 @@ def get_nutrition_for_food(nutritional_info, food_log):
         nutritional_info (dict): WW food info of the food the food log is tracking
         food_log (dict): food entry logging the food nutritional info was passed in
     """
-    return _get_nutrition_for_food(nutritional_info, food_log['portionName'], food_log['portionSize'])
+    return _get_nutrition_for_food(nutritional_info, food_log['portionId'], food_log['portionSize'])
 
 
-def _get_nutrition_for_food(nutritional_info, portion_name, amount_consumed):
+def _get_nutrition_for_food(nutritional_info, portion_id, amount_consumed):
     portions = nutritional_info['portions']
     for portion in portions:
-        if portion['name'] == portion_name:
+        if portion['_id'] == portion_id:
             return nutrition_times_portion(portion['nutrition'], amount_consumed/portion['size'])
-    raise ValueError("Failed to find portion {}".format(portion_name))
+    raise ValueError("Failed to find portion with id {}".format(portion_id))
 
 
 def nutrition_times_portion(nutritional_info, portions):


### PR DESCRIPTION
Changed method to find correct portion type from name-based to id-based. Relying on names could lead to wrong results because of different preparation styles with same name. E.g. "bottle (small)" vs. "bottle (medium)" have the same portionName in food_log. The loop catches the first winner which isn't always the right one.
